### PR TITLE
remove reference to divorce production, use AAT

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -15,7 +15,7 @@ def type = "nodejs"
 
     withNightlyPipeline(type, product, component) {
         
-        env.TEST_URL = 'https://www.apply-divorce.service.gov.uk'
+        env.TEST_URL = 'https://div-pfe-aat.service.core-compute-aat.internal'
        env.SAUCE_ACCESS_KEY='e0067992-049e-412c-9d15-2566a28cfb73'
         env.SAUCE_USERNAME='divorce'
         


### PR DESCRIPTION
# Description

This change removes a reference to the divorce production URL, to avoid tests running against our live site and creating test cases in CCD (which we're explicitly not allowed to do, as per the CCD team).

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
